### PR TITLE
Restore another property that is needed for j2cl to work. this breaks…

### DIFF
--- a/java/jsinterop/base/Js.java
+++ b/java/jsinterop/base/Js.java
@@ -23,7 +23,7 @@ import javaemul.internal.annotations.HasNoSideEffects;
 import javaemul.internal.annotations.UncheckedCast;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsProperty;
-// J2CL_ONLY import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsPackage;
 
 /**
  * Utilities to provide access to JavaScript language constructs that are not available in pure
@@ -46,7 +46,7 @@ public final class Js {
   @HasNoSideEffects
   public static native String typeof(Object obj);
 
-  // J2CL_ONLY @JsProperty(namespace=JsPackage.GLOBAL, name = "goog.global")
+  @JsProperty(namespace=JsPackage.GLOBAL, name = "goog.global")
   public static native JsPropertyMap<Object> global() /*-{
     return $wnd;
   }-*/;


### PR DESCRIPTION
- https://github.com/Vertispan/jsinterop-base/commit/20a8580abe55c2928fc316baeccdd2b1b23a50fd